### PR TITLE
Fix display and classification of files on GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.mac linguist-language=Roff
+*.t   linguist-language=Roff


### PR DESCRIPTION
GitHub doesn't recognise `.t` as a Roff extension, so it's identifying these files as either Perl or Turing:

<img src="https://user-images.githubusercontent.com/2346707/96059100-c5409180-0ed8-11eb-8b9c-7c7cc0f0e022.png" alt="Figure 1" />

The library GitHub uses for language recognition [provides a solution](https://github.com/github/linguist#overrides) to correct misclassified or unrecognised files. This PR makes use of that.